### PR TITLE
Removed double text in format hints

### DIFF
--- a/frontend/src/components/DataFormatHintAlert.jsx
+++ b/frontend/src/components/DataFormatHintAlert.jsx
@@ -8,26 +8,7 @@ import Stack from '@mui/material/Stack'
 import Typography from '@mui/material/Typography'
 import { InfoCircleOutlined } from '@ant-design/icons'
 
-// Derives the source URL directly from the article number, since every GDPR/EU AI Act
-// link in the backend (format_hints.py) follows one of exactly two fixed patterns.
-// This avoids relying on a format's relevant_articles list actually listing the article
-// referenced by a checklist item (it often doesn't — e.g. CSV's checklist cites
-// "Art. 6 GDPR" even though CSV's own relevant_articles never mentions Art. 6).
-// Combined references like "Art. 9/6 GDPR" resolve to the first (more severe) article.
-function resolveArticleUrl(article) {
-  if (!article) return undefined
-
-  const articleNumber = article.match(/Art\.\s*(\d+)/)?.[1]
-  if (!articleNumber) return undefined
-
-  if (article.includes('EU AI Act')) {
-    return `https://artificialintelligenceact.eu/article/${articleNumber}/`
-  }
-  if (article.includes('GDPR')) {
-    return `https://gdpr-info.eu/art-${articleNumber}-gdpr/`
-  }
-  return undefined
-}
+import { resolveArticleUrl } from 'utils/articleUrls'
 
 export default function DataFormatHintAlert({ hint }) {
   const [detailsOpen, setDetailsOpen] = useState(false)

--- a/frontend/src/components/DataFormatHintAlert.jsx
+++ b/frontend/src/components/DataFormatHintAlert.jsx
@@ -2,12 +2,32 @@ import { useState } from 'react'
 
 import Alert from '@mui/material/Alert'
 import Button from '@mui/material/Button'
-import Chip from '@mui/material/Chip'
 import Collapse from '@mui/material/Collapse'
 import Link from '@mui/material/Link'
 import Stack from '@mui/material/Stack'
 import Typography from '@mui/material/Typography'
 import { InfoCircleOutlined } from '@ant-design/icons'
+
+// Derives the source URL directly from the article number, since every GDPR/EU AI Act
+// link in the backend (format_hints.py) follows one of exactly two fixed patterns.
+// This avoids relying on a format's relevant_articles list actually listing the article
+// referenced by a checklist item (it often doesn't — e.g. CSV's checklist cites
+// "Art. 6 GDPR" even though CSV's own relevant_articles never mentions Art. 6).
+// Combined references like "Art. 9/6 GDPR" resolve to the first (more severe) article.
+function resolveArticleUrl(article) {
+  if (!article) return undefined
+
+  const articleNumber = article.match(/Art\.\s*(\d+)/)?.[1]
+  if (!articleNumber) return undefined
+
+  if (article.includes('EU AI Act')) {
+    return `https://artificialintelligenceact.eu/article/${articleNumber}/`
+  }
+  if (article.includes('GDPR')) {
+    return `https://gdpr-info.eu/art-${articleNumber}-gdpr/`
+  }
+  return undefined
+}
 
 export default function DataFormatHintAlert({ hint }) {
   const [detailsOpen, setDetailsOpen] = useState(false)
@@ -30,46 +50,31 @@ export default function DataFormatHintAlert({ hint }) {
 
         <Collapse in={detailsOpen}>
           <Stack spacing={1} sx={{ mt: 0.5 }}>
-            {/* Optional chaining guards against API responses predating these fields. */}
-            {hint.relevant_articles?.length > 0 && (
-              <Stack spacing={0.25}>
-                <Typography variant="body2" fontWeight={500}>Relevant GDPR / EU AI Act articles:</Typography>
-                {hint.relevant_articles.map((article) => (
-                  <Link
-                    key={article.title}
-                    href={article.url}
-                    target="_blank"
-                    rel="noopener noreferrer"
-                    variant="body2"
-                    underline="none"
-                    sx={{ color: 'rgb(113, 128, 150)', '&:hover': { color: 'primary.main' } }}
-                  >
-                    • {article.title}
-                  </Link>
-                ))}
-              </Stack>
-            )}
-
             {hint.checklist?.length > 0 && (
               <Stack spacing={0.25}>
                 <Typography variant="body2" fontWeight={500}>Check your data for:</Typography>
                 {hint.checklist.map((item) => {
                   const label = item?.label ?? item
-                  const weight = item?.weight
                   const article = item?.article
+                  const text = article ? `${article} — ${label}` : label
+                  const url = resolveArticleUrl(article)
+
+                  if (!url) {
+                    return <Typography key={label} variant="body2">• {text}</Typography>
+                  }
+
                   return (
-                    <Stack key={label} direction="row" spacing={1} sx={{ alignItems: 'center', flexWrap: 'wrap' }}>
-                      <Typography variant="body2">• {label}</Typography>
-                      {article && (
-                        <Chip
-                          size="small"
-                          label={article}
-                          color={weight === 3 ? 'error' : weight === 2 ? 'warning' : 'default'}
-                          variant="outlined"
-                          sx={{ fontSize: 11, height: 18, '& .MuiChip-label': { px: 0.75 } }}
-                        />
-                      )}
-                    </Stack>
+                    <Link
+                      key={label}
+                      href={url}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      variant="body2"
+                      underline="none"
+                      sx={{ color: 'rgb(113, 128, 150)', '&:hover': { color: 'primary.main' } }}
+                    >
+                      • {text}
+                    </Link>
                   )
                 })}
               </Stack>

--- a/frontend/src/pages/AddDataSource.jsx
+++ b/frontend/src/pages/AddDataSource.jsx
@@ -24,6 +24,7 @@ import DataFormatHintAlert from 'components/DataFormatHintAlert'
 import MainCard from 'components/MainCard'
 import { createDataSource, getDataFormatHints } from 'api/dataSources'
 import { getProjects } from 'api/projects'
+import { resolveArticleUrl } from 'utils/articleUrls'
 import { upsertCachedDataSource } from 'utils/data-source-cache'
 import ImportDataSourcesDialog from './ImportDataSourcesDialog'
 
@@ -400,6 +401,7 @@ export default function AddDataSource() {
                             const label = item?.label ?? item
                             const weight = item?.weight
                             const article = item?.article
+                            const articleUrl = resolveArticleUrl(article)
                             return (
                               <FormControlLabel
                                 key={label}
@@ -415,13 +417,21 @@ export default function AddDataSource() {
                                 label={
                                   <Stack direction="row" spacing={1} sx={{ alignItems: 'center', flexWrap: 'wrap' }}>
                                     <Typography variant="body2">{label}</Typography>
-                                    {/* Article chip color reflects GDPR fine tier: weight 3 = red (Art. 9), 2 = yellow, 1 = grey */}
+                                    {/* Article chip color reflects GDPR fine tier: weight 3 = red (Art. 9), 2 = yellow, 1 = grey.
+                                        preventDefault+stopPropagation keep the click from also toggling the checkbox,
+                                        since the chip sits inside the FormControlLabel's native <label> element. */}
                                     {article && (
                                       <Chip
                                         size="small"
                                         label={article}
                                         color={weight === 3 ? 'error' : weight === 2 ? 'warning' : 'default'}
                                         variant="outlined"
+                                        clickable={Boolean(articleUrl)}
+                                        onClick={articleUrl ? (e) => {
+                                          e.preventDefault()
+                                          e.stopPropagation()
+                                          window.open(articleUrl, '_blank', 'noopener,noreferrer')
+                                        } : undefined}
                                         sx={{ fontSize: 11, height: 18, '& .MuiChip-label': { px: 0.75 } }}
                                       />
                                     )}

--- a/frontend/src/pages/EditDataSource.jsx
+++ b/frontend/src/pages/EditDataSource.jsx
@@ -28,6 +28,7 @@ import DataFormatHintAlert from 'components/DataFormatHintAlert'
 import MainCard from 'components/MainCard'
 import { deleteDataSource, getDataFormatHints, getDataSource, updateDataSource } from 'api/dataSources'
 import { getProjects } from 'api/projects'
+import { resolveArticleUrl } from 'utils/articleUrls'
 import { removeCachedDataSource, upsertCachedDataSource } from 'utils/data-source-cache'
 
 const sourceTypeOptions = [
@@ -456,6 +457,7 @@ export default function EditDataSource() {
                                 const label = item?.label ?? item
                                 const weight = item?.weight
                                 const article = item?.article
+                                const articleUrl = resolveArticleUrl(article)
                                 return (
                                   <FormControlLabel
                                     key={label}
@@ -471,12 +473,20 @@ export default function EditDataSource() {
                                     label={
                                       <Stack direction="row" spacing={1} sx={{ alignItems: 'center', flexWrap: 'wrap' }}>
                                         <Typography variant="body2">{label}</Typography>
+                                        {/* preventDefault+stopPropagation keep the click from also toggling the checkbox,
+                                            since the chip sits inside the FormControlLabel's native <label> element. */}
                                         {article && (
                                           <Chip
                                             size="small"
                                             label={article}
                                             color={weight === 3 ? 'error' : weight === 2 ? 'warning' : 'default'}
                                             variant="outlined"
+                                            clickable={Boolean(articleUrl)}
+                                            onClick={articleUrl ? (e) => {
+                                              e.preventDefault()
+                                              e.stopPropagation()
+                                              window.open(articleUrl, '_blank', 'noopener,noreferrer')
+                                            } : undefined}
                                             sx={{ fontSize: 11, height: 18, '& .MuiChip-label': { px: 0.75 } }}
                                           />
                                         )}

--- a/frontend/src/utils/articleUrls.js
+++ b/frontend/src/utils/articleUrls.js
@@ -1,0 +1,20 @@
+// Derives the source URL directly from the article number, since every GDPR/EU AI Act
+// link in the backend (format_hints.py / violation_weights.py) follows one of exactly
+// two fixed patterns. This avoids depending on a format's relevant_articles list actually
+// listing the article referenced by a checklist item (it often doesn't — e.g. CSV's
+// checklist cites "Art. 6 GDPR" even though CSV's own relevant_articles never mentions it).
+// Combined references like "Art. 9/6 GDPR" resolve to the first (more severe) article.
+export function resolveArticleUrl(article) {
+  if (!article) return undefined
+
+  const articleNumber = article.match(/Art\.\s*(\d+)/)?.[1]
+  if (!articleNumber) return undefined
+
+  if (article.includes('EU AI Act')) {
+    return `https://artificialintelligenceact.eu/article/${articleNumber}/`
+  }
+  if (article.includes('GDPR')) {
+    return `https://gdpr-info.eu/art-${articleNumber}-gdpr/`
+  }
+  return undefined
+}


### PR DESCRIPTION
This PR's is just about removing the redundant text. 

Old: 
<img width="1176" height="622" alt="Bildschirmfoto 2026-07-16 um 23 06 11" src="https://github.com/user-attachments/assets/bd6e5bcd-b142-450d-a17d-95949c2672a2" />


New: 
<img width="1093" height="353" alt="Bildschirmfoto 2026-07-17 um 08 49 12" src="https://github.com/user-attachments/assets/1ca7cd8a-66a5-4da0-a9ec-2cef20a7c7a5" />


Basically the upper text was removed but its style was used for the lower text

Also the Boxes on the checklist now contains links:
<img width="1093" height="402" alt="Bildschirmfoto 2026-07-17 um 09 02 53" src="https://github.com/user-attachments/assets/60714385-e6fc-4ba0-b733-bbab206e7a66" />
