### PR TITLE
Fix default route to redirect to login

### DIFF
--- a/frontend/src/routes/index.jsx
+++ b/frontend/src/routes/index.jsx
@@ -16,6 +16,10 @@ import ResetPassword from 'pages/ResetPassword'
 const router = createBrowserRouter(
   [
     {
+      path: '/',
+      element: <Navigate to="/login" replace />,
+    },
+    {
       path: '/login',
       element: <Login />,
     },
@@ -35,10 +39,6 @@ const router = createBrowserRouter(
       path: '/',
       element: <DashboardLayout />,
       children: [
-        {
-          index: true,
-          element: <Navigate to="/dashboard" replace />,
-        },
         {
           path: 'dashboard',
           element: <Dashboard />,


### PR DESCRIPTION
# Summary

Fixes the default frontend routing behavior.

## What Changed

- Redirects `/` directly to `/login`.
- Prevents the Dashboard layout from briefly appearing before the Login page.
- Keeps existing application routes unchanged.

## Files Changed

- `frontend/src/routes/index.jsx`